### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/OpenIdAuthentication/cloudformation/QuickSightEmbeddingLambda.json
+++ b/OpenIdAuthentication/cloudformation/QuickSightEmbeddingLambda.json
@@ -25,7 +25,7 @@
         "Handler": "index.handler",
         "Timeout" : 50,
         "Role": { "Fn::GetAtt": ["LambdaExecutionRole", "Arn"]},
-        "Runtime": "nodejs8.10"
+        "Runtime": "nodejs10.x"
       }
     },
 

--- a/OpenIdAuthentication/cloudformation/QuickSightEmbeddingLambda.json
+++ b/OpenIdAuthentication/cloudformation/QuickSightEmbeddingLambda.json
@@ -25,7 +25,7 @@
         "Handler": "index.handler",
         "Timeout" : 50,
         "Role": { "Fn::GetAtt": ["LambdaExecutionRole", "Arn"]},
-        "Runtime": "nodejs10.x"
+        "Runtime": "nodejs12.x"
       }
     },
 

--- a/QuickSightAuthentication/cloudformation/QuickSightEmbeddingLambda.json
+++ b/QuickSightAuthentication/cloudformation/QuickSightEmbeddingLambda.json
@@ -25,7 +25,7 @@
         "Handler": "index.handler",
         "Timeout" : 50,
         "Role": { "Fn::GetAtt": ["LambdaExecutionRole", "Arn"]},
-        "Runtime": "nodejs8.10"
+        "Runtime": "nodejs10.x"
       }
     },
 

--- a/QuickSightAuthentication/cloudformation/QuickSightEmbeddingLambda.json
+++ b/QuickSightAuthentication/cloudformation/QuickSightEmbeddingLambda.json
@@ -25,7 +25,7 @@
         "Handler": "index.handler",
         "Timeout" : 50,
         "Role": { "Fn::GetAtt": ["LambdaExecutionRole", "Arn"]},
-        "Runtime": "nodejs10.x"
+        "Runtime": "nodejs12.x"
       }
     },
 


### PR DESCRIPTION
CloudFormation templates in amazon-quicksight-embedding-sample have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.